### PR TITLE
Update uffminimize.py

### DIFF
--- a/uffminimize.py
+++ b/uffminimize.py
@@ -30,7 +30,12 @@ for mol in inmols:
     if mol is not None:
         try:
             orig = Chem.UFFGetMoleculeForceField(mol).CalcEnergy()
-            Chem.UFFOptimizeMolecule(mol)
+            a=Chem.UFFOptimizeMolecule(mol)
+            
+            #sometimes the UFF Optimization does not converge (returns a 1 instead of 0)
+            if a==1:
+              a=Chem.UFFOptimizeMolecule(mol, maxIter=1000)
+            
             if options.verbose:
                 e = Chem.UFFGetMoleculeForceField(mol).CalcEnergy()
                 print mol.GetProp('_Name'),orig,"->",e


### PR DESCRIPTION
Added a check to expand the number of iterations that the compounds go through in the UFFOptimizeMolecule procedure if it failed to converge the first time around. I set the maxIters up from the default of 200 to 1000. This still runs reasonably quickly, and can help in the generation of improper compounds.